### PR TITLE
fix: key generation not taking path parameters into account

### DIFF
--- a/src/runtime/useFetch.ts
+++ b/src/runtime/useFetch.ts
@@ -68,6 +68,7 @@ export function createUseOpenFetch<
     const key = hash({
       url: (typeof url === 'string' ? url : url()),
       method: options.method,
+      path: options.path,
       query: options.query,
       body: options.body,
     })


### PR DESCRIPTION
This PR improves the key generation by taking the path parameters into account. 

Currently, when a URL contains path parameters (e.g. `/api/products/{id}`), these parameters are not used in the key generation.

Consider these requests: 

```ts
useApi('/api/products/{id}`, {
    path: {
        id: 12
    }
})

useApi('/api/products/{id}`, {
    path: {
        id: 30
    }
})

useApi('/api/products/{id}`, {
    path: {
        id: 90
    }
})
```


In this example, all requests are using the same URL `'/api/products/{id}'` and therefore same key. 
With this PR, the path parameters are discriminating all these requests and they will produce the expected result.

Quick note aside @Norbiros, do you have any news of the original package maintainer, @enkot?  
The package is awesome but he has been (almost) inactive for quite some time now and the lack of maintenance is not very appealing for new users :(